### PR TITLE
Ignore build tags for packages in GOROOT too.

### DIFF
--- a/main.go
+++ b/main.go
@@ -292,7 +292,18 @@ func tryLocal(importPath, rev string) (*build.Package, string, vfs.FileSystem, e
 			return nil, "", nil, errors.New("custom revision not yet supported for GOROOT packages")
 		}
 
-		return goPackage.Bpkg, "", vfs.OS(""), nil
+		var context build.Context = build.Default
+		context.UseAllFiles = true
+		bpkg, err1 := context.Import(importPath, "", 0)
+		// TODO: Currently, MultiplePackageError may result in incomplete package being returned. Need to do something about that.
+		//       I think it might be an issue in go/build; perhaps it makes sense not to return MultiplePackageError when UseAllFiles is
+		//       explicitly set to true. It might not be an issue in go/build though, I haven't investigated closely enough yet.
+		if _, multiplePackage := err1.(*build.MultiplePackageError); multiplePackage {
+			err1 = nil
+		}
+		if err1 == nil {
+			return bpkg, "", vfs.OS(""), nil
+		}
 	}
 
 	// TESTING: Disable local for non-standard library packages.
@@ -376,8 +387,14 @@ func try(importPath, rev string) (*build.Package, string, vfs.FileSystem, []stri
 
 	context := buildContextUsingFS(fs)
 	context.GOPATH = "/virtual-go-workspace"
-	context.UseAllFiles = true // TODO: Also do this for local packages.
+	context.UseAllFiles = true
 	bpkg, err1 := context.Import(importPath, "", 0)
+	// TODO: Currently, MultiplePackageError may result in incomplete package being returned. Need to do something about that.
+	//       I think it might be an issue in go/build; perhaps it makes sense not to return MultiplePackageError when UseAllFiles is
+	//       explicitly set to true. It might not be an issue in go/build though, I haven't investigated closely enough yet.
+	if _, multiplePackage := err1.(*build.MultiplePackageError); multiplePackage {
+		err1 = nil
+	}
 	if err1 == nil {
 		return bpkg, repoImportPath, fs, branchNames, defaultBranch, nil
 	}


### PR DESCRIPTION
Current approach of using `build.Import` with `UseAllFiles` set to `true` may result in `MultiplePackageError` and an incomplete package being returned. Need to find a way to fix that. This is the best intermediate solution for now.

Fixes #13.
