### PR TITLE
Automatically check for updates on repo/branch visit; display yellow notification box if the page is outdated.

### DIFF
--- a/assets/code.html.tmpl
+++ b/assets/code.html.tmpl
@@ -15,6 +15,7 @@
 				<div style="padding-bottom: 50px;">
 					<div style="padding: 30px;">
 						<h1>{{.ImportPathElements}}</h1>
+						{{template "outdated" $}}
 						{{with .Commit}}<p>Commit {{template "commitId" .ID}} from {{template "time" .Author.Date.Time}}.</p>{{end}}
 						{{with .Branches}}<p><span class="spacing" title="Branch"><span class="octicon octicon-git-branch" style="margin-right: 8px;"></span>{{.}}</span></p>{{end}}
 						{{if .Folders}}

--- a/assets/code.html.tmpl
+++ b/assets/code.html.tmpl
@@ -5,6 +5,10 @@
 		<link href="/assets/select-list-view.css" media="all" rel="stylesheet" type="text/css" />
 		<link href="/assets/table-of-contents.css" media="all" rel="stylesheet" type="text/css" />
 		{{if .Production}}{{template "GA"}}{{end}}
+		<script type="text/javascript">
+			{{/*var State = {{.FrontendState | json}};*/}}
+			var State = {{.FrontendState}};
+		</script>
 		<script type="text/javascript" src="/assets/script/script.js"></script>
 		<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/octicons/2.2.0/octicons.css">
 	</head>

--- a/assets/code.html.tmpl
+++ b/assets/code.html.tmpl
@@ -6,8 +6,7 @@
 		<link href="/assets/table-of-contents.css" media="all" rel="stylesheet" type="text/css" />
 		{{if .Production}}{{template "GA"}}{{end}}
 		<script type="text/javascript">
-			{{/*var State = {{.FrontendState | json}};*/}}
-			var State = {{.FrontendState}};
+			var StateJSON = "{{.FrontendState | json}}";
 		</script>
 		<script type="text/javascript" src="/assets/script/script.js"></script>
 		<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/octicons/2.2.0/octicons.css">

--- a/assets/script/script.go
+++ b/assets/script/script.go
@@ -183,9 +183,14 @@ func offsetTopRoot(e dom.HTMLElement) float64 {
 	return offsetTopRoot
 }
 
+func HideOutdatedBox() {
+	document.GetElementByID("outdated-box").(dom.HTMLElement).Style().SetProperty("display", "none", "")
+}
+
 func init() {
 	js.Global.Set("MustScrollTo", jsutil.Wrap(MustScrollTo))
 	js.Global.Set("LineNumber", jsutil.Wrap(LineNumber))
+	js.Global.Set("HideOutdatedBox", HideOutdatedBox)
 
 	processHashSet := func() {
 		// Scroll to hash target.

--- a/assets/script/script.go
+++ b/assets/script/script.go
@@ -297,9 +297,6 @@ func init() {
 				"RepoSpec.CloneURL": {state.RepoSpec.CloneURL},
 			}.Encode(),
 		}
-		if state.Production {
-			u.Host = "gotools.org:26203"
-		}
 
 		source := eventsource.New(u.String())
 		source.AddEventListener("message", false, func(event *js.Object) {

--- a/assets/script/script.go
+++ b/assets/script/script.go
@@ -13,8 +13,10 @@ import (
 	_ "github.com/shurcooL/frontend/select-list-view"
 	_ "github.com/shurcooL/frontend/select_menu"
 	_ "github.com/shurcooL/frontend/table-of-contents"
+	"github.com/shurcooL/go-goon"
 	"github.com/shurcooL/go/gopherjs_http/jsutil"
 	"github.com/shurcooL/gtdo/gtdo"
+	"github.com/shurcooL/gtdo/page"
 	"honnef.co/go/js/dom"
 )
 
@@ -266,6 +268,18 @@ func init() {
 			ke.PreventDefault()
 		}
 	})
+
+	/*stateJSON := js.Global.Get("State").String()
+	fmt.Println(stateJSON)
+	var state page.State
+	err := json.Unmarshal([]byte(stateJSON), &state)
+	if err != nil {
+		panic(err)
+	}*/
+	var state page.StateObject
+	state.Object = js.Global.Get("State")
+
+	goon.Dump(state)
 }
 
 func main() {}

--- a/assets/script/script.go
+++ b/assets/script/script.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -273,20 +274,13 @@ func init() {
 		}
 	})
 
-	/*stateJSON := js.Global.Get("State").String()
-	fmt.Println(stateJSON)
 	var state page.State
-	err := json.Unmarshal([]byte(stateJSON), &state)
+	err := json.Unmarshal([]byte(js.Global.Get("StateJSON").String()), &state)
 	if err != nil {
 		panic(err)
-	}*/
-	var state page.StateObject
-	state.Object = js.Global.Get("State")
+	}
 
-	//goon.Dump(state)
-	//goon.Dump(state.RepoSpec)
-
-	// WIP: EventSource updates.
+	// EventSource updates.
 	if state.RepoSpec.CloneURL != "" {
 		u := url.URL{
 			Path: "/-/events",

--- a/assets/style.css
+++ b/assets/style.css
@@ -119,6 +119,7 @@ h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor, h5:hover
 }
 
 div.outdated {
+	display: none;
 	font-size: 14px;
 	background-color: rgb(255, 249, 236);
 	border: 1px solid rgb(224, 216, 196);

--- a/assets/style.css
+++ b/assets/style.css
@@ -118,6 +118,28 @@ h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor, h5:hover
 	background-color: #eeeeee;
 }
 
+div.outdated {
+	font-size: 14px;
+	background-color: rgb(255, 249, 236);
+	border: 1px solid rgb(224, 216, 196);
+	border-radius: 3px;
+	padding: 12px;
+}
+div.outdated span.content {
+	display: table-cell;
+	width: 100%;
+}
+div.outdated span.close {
+	display: table-cell;
+	padding-left: 8px;
+}
+div.outdated span.close a {
+	color: #bbb;
+}
+div.outdated span.close a:hover {
+	color: black;
+}
+
 * {
 	tab-size: 4;
 }

--- a/assets/util.html.tmpl
+++ b/assets/util.html.tmpl
@@ -1,3 +1,5 @@
 {{define "commitId"}}<abbr id="commit-id" title="{{.}}"><code>{{commitId .}}</code></abbr>{{end}}
 
 {{define "time"}}<abbr title="{{.}}">{{time .}}</abbr>{{end}}
+
+{{define "outdated"}}<div class="outdated" id="outdated-box"><span class="content">This page is out of date. <a href="/{{$.ImportPath}}{{fullQuery $.RawQuery}}">Refresh</a> to see the latest.</span><span class="close"><a href="javascript:HideOutdatedBox();"><span class="octicon octicon-x"></span></a></span></div>{{end}}

--- a/doc_handler.go
+++ b/doc_handler.go
@@ -112,12 +112,7 @@ func summaryHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if bpkg != nil {
-		sendToTop(bpkg.ImportPath)
-	}
-	if RepoUpdater != nil && repoSpec != nil {
-		RepoUpdater.Enqueue(*repoSpec)
-	}
+	afterPackageVisit(bpkg, repoSpec)
 }
 
 func importsHandler(w http.ResponseWriter, req *http.Request) {
@@ -218,12 +213,7 @@ func importsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if bpkg != nil {
-		sendToTop(bpkg.ImportPath)
-	}
-	if RepoUpdater != nil && repoSpec != nil {
-		RepoUpdater.Enqueue(*repoSpec)
-	}
+	afterPackageVisit(bpkg, repoSpec)
 }
 
 func docPackage(fs vfs.FileSystem, bpkg *build.Package) (*doc.Package, error) {

--- a/events.go
+++ b/events.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+)
+
+type importPathBranch struct {
+	importPath string
+	branch     string
+}
+
+var (
+	sseMu sync.Mutex
+	sse   map[importPathBranch][]pageViewer
+)
+
+type pageViewer struct {
+	id       *http.ResponseWriter
+	outdated chan struct{}
+}
+
+// NotifyOutdated is called by repo updater when the given page viewer is outdated.
+// It returns immediately.
+func (pv *pageViewer) NotifyOutdated() {
+	select {
+	case pv.outdated <- struct{}{}:
+	default:
+	}
+}
+
+func eventsHandler(w http.ResponseWriter, req *http.Request) {
+	log.Println("eventsHandler method:", req.Method)
+
+	// TODO: Dedup query keys.
+	importPathBranch := importPathBranch{
+		importPath: req.URL.Query().Get("ImportPath"),
+		branch:     req.URL.Query().Get("Branch"),
+	}
+	repoSpec := repoSpec{
+		importPath: importPathBranch.importPath,
+		vcsType:    req.URL.Query().Get("RepoSpec.VCSType"),
+		cloneURL:   req.URL.Query().Get("RepoSpec.CloneURL"),
+	}
+	if repoSpec.vcsType == "" || repoSpec.cloneURL == "" {
+		log.Println("Invalid repoSpec:", repoSpec)
+		http.Error(w, "Invalid repoSpec.", http.StatusBadRequest)
+		return
+	}
+	RepoUpdater.Enqueue(repoSpec)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		log.Println("Streaming unsupported.")
+		http.Error(w, "Streaming unsupported.", http.StatusInternalServerError)
+		return
+	}
+
+	closeNotifier, ok := w.(http.CloseNotifier)
+	if !ok {
+		log.Println("CloseNotifier unsupported.")
+		http.Error(w, "CloseNotifier unsupported.", http.StatusInternalServerError)
+		return
+	}
+	closeChan := closeNotifier.CloseNotify()
+
+	outdatedChan := make(chan struct{}, 1)
+	{
+		log.Println("Client connection joined:", &w)
+		sseMu.Lock()
+		sse[importPathBranch] = append(sse[importPathBranch], pageViewer{
+			id:       &w,
+			outdated: outdatedChan,
+		})
+		sseMu.Unlock()
+	}
+	defer func() {
+		sseMu.Lock()
+		for i, pv := range sse[importPathBranch] {
+			if pv.id == &w {
+				// Delete without preserving order.
+				sse[importPathBranch][i] = sse[importPathBranch][len(sse[importPathBranch])-1]
+				sse[importPathBranch][len(sse[importPathBranch])-1] = pageViewer{}
+				sse[importPathBranch] = sse[importPathBranch][:len(sse[importPathBranch])-1]
+				if len(sse[importPathBranch]) == 0 {
+					delete(sse, importPathBranch)
+				}
+				log.Println("Client connection gone away:", &w)
+				break
+			}
+		}
+		sseMu.Unlock()
+	}()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	/*w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")*/
+	if *productionFlag {
+		w.Header().Set("Access-Control-Allow-Origin", "http://gotools.org")
+	}
+
+	for {
+		select {
+		case <-outdatedChan:
+			_, err := fmt.Fprintf(w, "data: %s\n\n", "outdated")
+			if err != nil {
+				log.Println("(via write error:", err)
+				return
+			}
+
+			flusher.Flush()
+		case <-closeChan:
+			log.Println("(via CloseNotifier)")
+			return
+			//case <-time.After(10 * time.Second):
+		}
+	}
+}

--- a/importers_handler.go
+++ b/importers_handler.go
@@ -99,10 +99,5 @@ func importersHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if bpkg != nil {
-		sendToTop(bpkg.ImportPath)
-	}
-	if RepoUpdater != nil && repoSpec != nil {
-		RepoUpdater.Enqueue(*repoSpec)
-	}
+	afterPackageVisit(bpkg, repoSpec)
 }

--- a/page/state.go
+++ b/page/state.go
@@ -1,0 +1,23 @@
+package page
+
+import "github.com/gopherjs/gopherjs/js"
+
+// State that is passed to the frontend script from the backend handler.
+type State struct {
+	// TODO: Consider *js.Object.
+	ImportPath   string
+	ProcessedRev string // ProcessedRev is processed rev; its value is replaced by default branch if empty.
+	CommitID     string // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
+}
+
+// TODO: Dedup. It's duplicated because including *js.Object in backend makes it panic because of:
+//
+//           runtime error: invalid memory address or nil pointer dereference
+//
+//       It happens in call to html/template.(*Template).ExecuteTemplate().
+type StateObject struct {
+	*js.Object
+	ImportPath   string `js:"ImportPath"`   // TODO: Consider changing GopherJS so this explicit js tag isn't needed?
+	ProcessedRev string `js:"ProcessedRev"` // ProcessedRev is processed rev; its value is replaced by default branch if empty.
+	CommitID     string `js:"CommitID"`     // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
+}

--- a/page/state.go
+++ b/page/state.go
@@ -1,10 +1,7 @@
 package page
 
-import "github.com/gopherjs/gopherjs/js"
-
 // State that is passed to the frontend script from the backend handler.
 type State struct {
-	// TODO: Consider *js.Object.
 	Production   bool
 	ImportPath   string
 	RepoSpec     repoSpec
@@ -12,30 +9,9 @@ type State struct {
 	CommitID     string // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
 }
 
-// TODO: Dedup.
-// repoSpec identifies a repository.
+// TODO: Dedup. But probably by moving it to a common lower level package for types... Not sure if this package is best for it.
+// repoSpec identifies a repository for go-vcs purposes.
 type repoSpec struct {
 	VCSType  string
 	CloneURL string
-}
-
-// TODO: Dedup. It's duplicated because including *js.Object in backend makes it panic because of:
-//
-//           runtime error: invalid memory address or nil pointer dereference
-//
-//       It happens in call to html/template.(*Template).ExecuteTemplate().
-type StateObject struct {
-	*js.Object
-	Production   bool           `js:"Production"`
-	ImportPath   string         `js:"ImportPath"` // TODO: Consider changing GopherJS so this explicit js tag isn't needed?
-	RepoSpec     repoSpecObject `js:"RepoSpec"`
-	ProcessedRev string         `js:"ProcessedRev"` // ProcessedRev is processed rev; its value is replaced by default branch if empty.
-	CommitID     string         `js:"CommitID"`     // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
-}
-
-// TODO: Dedup. It's duplicated because including *js.Object in backend makes it panic.
-type repoSpecObject struct {
-	*js.Object
-	VCSType  string `js:"VCSType"`
-	CloneURL string `js:"CloneURL"`
 }

--- a/page/state.go
+++ b/page/state.go
@@ -5,9 +5,18 @@ import "github.com/gopherjs/gopherjs/js"
 // State that is passed to the frontend script from the backend handler.
 type State struct {
 	// TODO: Consider *js.Object.
+	Production   bool
 	ImportPath   string
+	RepoSpec     repoSpec
 	ProcessedRev string // ProcessedRev is processed rev; its value is replaced by default branch if empty.
 	CommitID     string // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
+}
+
+// TODO: Dedup.
+// repoSpec identifies a repository.
+type repoSpec struct {
+	VCSType  string
+	CloneURL string
 }
 
 // TODO: Dedup. It's duplicated because including *js.Object in backend makes it panic because of:
@@ -17,7 +26,16 @@ type State struct {
 //       It happens in call to html/template.(*Template).ExecuteTemplate().
 type StateObject struct {
 	*js.Object
-	ImportPath   string `js:"ImportPath"`   // TODO: Consider changing GopherJS so this explicit js tag isn't needed?
-	ProcessedRev string `js:"ProcessedRev"` // ProcessedRev is processed rev; its value is replaced by default branch if empty.
-	CommitID     string `js:"CommitID"`     // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
+	Production   bool           `js:"Production"`
+	ImportPath   string         `js:"ImportPath"` // TODO: Consider changing GopherJS so this explicit js tag isn't needed?
+	RepoSpec     repoSpecObject `js:"RepoSpec"`
+	ProcessedRev string         `js:"ProcessedRev"` // ProcessedRev is processed rev; its value is replaced by default branch if empty.
+	CommitID     string         `js:"CommitID"`     // TODO: Either get rid of godep or make gopherjs_http.NewFS use Godeps.json versions, then can start using vcs.CommitID directly.
+}
+
+// TODO: Dedup. It's duplicated because including *js.Object in backend makes it panic.
+type repoSpecObject struct {
+	*js.Object
+	VCSType  string `js:"VCSType"`
+	CloneURL string `js:"CloneURL"`
 }

--- a/repo_updater.go
+++ b/repo_updater.go
@@ -90,7 +90,8 @@ func (ru *repoUpdater) worker() {
 
 		result, err := repo.(vcs.RemoteUpdater).UpdateEverything(vcs.RemoteOpts{})
 		if err != nil {
-			fmt.Println("repoUpdater: UpdateEverything:", err)
+			log.Println("repoUpdater: UpdateEverything:", err)
+			continue
 		}
 
 		fmt.Println("taken:", time.Since(started))


### PR DESCRIPTION
Resolves #30.

This makes repo updates completely automated and extremely user friendly. It eliminates the possibility of navigating to a new branch/repo and looking at an outdated commit for very long.

It looks like this. When the branch you're looking at is detected to be outdated, a yellow notification warns you about it:

![image](https://cloud.githubusercontent.com/assets/1924134/9845790/861c69b2-5a82-11e5-928e-79722684c8ec.png)

Here's a [30-second video](http://virtivia.com:27080/axhnlp0o54bb.mov) of it in action.

It's implemented via Server-Sent Events.

When anyone navigates to a new repo/branch, a repository update request is enqueued. If that repo hasn't been already queued to be updated within the last 10 seconds, it gets queued and a background worker will soon check it for updates.

If updates to the branch the user is looking at are detected, an "outdated" message is sent via the SSE, which causes the user's page to display the yellow outdated notification bar.
