### PR TITLE
Support all branches/tags of Go standard library.

### DIFF
--- a/localgoroot.go
+++ b/localgoroot.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"go/build"
+	"io/ioutil"
+	"path/filepath"
+)
+
+var LocalGoVersion string
+
+func localGoVersion() (string, error) {
+	version, err := ioutil.ReadFile(filepath.Join(build.Default.GOROOT, "VERSION"))
+	if err != nil {
+		return "", err
+	}
+	return string(version), nil
+}


### PR DESCRIPTION
This change allows viewing any package in the standard library (i.e., inside $GOROOT/src) via the remote Go repository. That enables viewing code at any revision, tag, branch, or even CL. Previously, it was only possible to view GOROOT code of the current stable release of Go.

This should be helpful when developing Go and wanting to see/compare code or other information about packages in GOROOT.

When requested revision matches the installed Go version available at `/usr/local/go`, use it because it's slightly faster to serve files from disk than a git repository.

Resolves #45.